### PR TITLE
Add missing cstring include

### DIFF
--- a/src/BiConfig.hpp
+++ b/src/BiConfig.hpp
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <string>
+#include <cstring>
 #include "SimpleLinker.hpp"
 
 struct IDataStream


### PR DESCRIPTION
## Summary
- include `<cstring>` in `BiConfig.hpp` to access strlen and memcpy

## Testing
- `g++ -std=c++17 -c test.cpp -I .`

------
https://chatgpt.com/codex/tasks/task_e_683fe6af61a88327b967fd0a581b4375